### PR TITLE
Minor packaging updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,18 +51,11 @@ install(PROGRAMS
   src/condor_ce_metric
   src/condor_ce_view
   src/gratia_cleanup.py
-  contrib/bdii/htcondor-ce-provider
-  DESTINATION ${SHARE_INSTALL_PREFIX}/condor-ce)
-
-install(PROGRAMS
   contrib/apelscripts/condor_ce_blah.sh
   contrib/apelscripts/condor_batch.sh
   contrib/apelscripts/accountingRun.sh
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-install(FILES
-  contrib/apelscripts/htcondorce.cfg
-  contrib/apelscripts/README.md
-  DESTINATION ${SYSCONF_INSTALL_DIR}/apel)
+  contrib/bdii/htcondor-ce-provider
+  DESTINATION ${SHARE_INSTALL_PREFIX}/condor-ce)
 
 install(PROGRAMS
   src/condor_ce_config_generator
@@ -100,6 +93,12 @@ install(FILES
   DESTINATION ${PYTHON_SITELIB}/htcondorce)
 
 install(FILES config/condor_config config/condor_mapfile config/condor_mapfile.osg DESTINATION ${SYSCONF_INSTALL_DIR}/condor-ce)
+
+install(FILES
+  contrib/apelscripts/htcondorce.cfg
+  contrib/apelscripts/README.md
+  DESTINATION ${SYSCONF_INSTALL_DIR}/condor-ce/apel)
+
 install(FILES
   config/metrics.d/00-metrics-defaults.conf
   config/metrics.d/00-example-metrics.conf

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -78,7 +78,7 @@ Requires: %{name} = %{version}-%{release}, bdii
 %endif
 
 %if ! 0%{?osg}
-%package apelscripts
+%package apel
 Group: Applications/Internet
 Summary: Scripts for writing accounting log files in APEL format, blah (ce) and batch (runtimes)
 
@@ -87,7 +87,7 @@ Requires: apel-client >= 1.8.0
 Requires: apel-parsers >= 1.8.0
 Requires: apel-ssm
 
-%description apelscripts
+%description apel
 %{summary}
 %endif
 
@@ -371,7 +371,7 @@ fi
 
 
 %if ! 0%{?osg}
-%files apelscripts
+%files apel
 %{_sysconfdir}/condor-ce/apel/README.md
 %{_datadir}/condor-ce/condor_ce_blah.sh
 %{_datadir}/condor-ce/condor_batch.sh

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -228,6 +228,10 @@ rm $RPM_BUILD_ROOT%{_tmpfilesdir}/condor-ce{,-collector}.conf
 rm -rf $RPM_BUILD_ROOT%{_datadir}/condor-ce/htcondor-ce-provider
 rm -f $RPM_BUILD_ROOT%{_sysconfdir}/condor/config.d/50-ce-bdii-defaults.conf
 rm -f $RPM_BUILD_ROOT%{_sysconfdir}/condor/config.d/99-ce-bdii.conf
+rm -rf $RPM_BUILD_ROOT%{_sysconfdir}/condor-ce/apel
+rm -f $RPM_BUILD_ROOT%{_datadir}/condor-ce/condor_ce_blah.sh
+rm -f $RPM_BUILD_ROOT%{_datadir}/condor-ce/condor_batch.sh
+rm -f $RPM_BUILD_ROOT%{_datadir}/condor-ce/accountingRun.sh
 %else
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/bdii/gip/provider
 mv $RPM_BUILD_ROOT%{_datadir}/condor-ce/htcondor-ce-provider \
@@ -368,12 +372,12 @@ fi
 
 %if ! 0%{?osg}
 %files apelscripts
-%{_sysconfdir}/apel/README.md
-%{_bindir}/condor_ce_blah.sh
-%{_bindir}/condor_batch.sh
-%{_bindir}/accountingRun.sh
-%config(noreplace) %{_sysconfdir}/apel/htcondorce.cfg
-%attr(-,root,root) %dir %{_sysconfdir}/apel/
+%{_sysconfdir}/condor-ce/apel/README.md
+%{_datadir}/condor-ce/condor_ce_blah.sh
+%{_datadir}/condor-ce/condor_batch.sh
+%{_datadir}/condor-ce/accountingRun.sh
+%config(noreplace) %{_sysconfdir}/condor-ce/apel/htcondorce.cfg
+%attr(-,root,root) %dir %{_sysconfdir}/condor-ce/apel/
 %attr(-,root,root) %dir %{_localstatedir}/lib/condor-ce/apel/
 %endif
 


### PR DESCRIPTION
Some updates to opensciencegrid/htcondor-ce#222

1. Scripts aren't intended to be run directly by users
2. Configuration should live under the condor-ce dirs
3. `apelscripts` seemed a little verbose, `htcondor-ce-apel` works just as well, imo